### PR TITLE
Preparing AirBrush 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # AirBrush changelog
 
+## Version 0.6.1
+
+A few enhancements: 
+- TinyThumbDecoder now supports a different default base64 decode flag.
+- TinyThumb can now override the default base64 decode flag.
+- Removed bitmapProvider from TinyThumbDecoder. A custom decoder class should be used instead.
+- Added @JvmOverload to better support default arguments from Java
+- Added more documentation
+- Upgraded to latest kotlin and support library versions
+
 ## Version 0.6.0
 Big rewrite for optimization.
 - Using Glide 4 and custom loaders to for thumbnails.

--- a/airbrush/build.gradle
+++ b/airbrush/build.gradle
@@ -16,7 +16,7 @@ ext {
     siteUrl = 'https://github.com/frel/AirBrush'
     gitUrl = 'https://github.com/frel/AirBrush.git'
 
-    libraryVersion = '0.6.0'
+    libraryVersion = '0.6.1'
 
     developerId = 'frel'
     developerName = 'Fredrik H. Larsen'
@@ -34,7 +34,7 @@ android {
         targetSdkVersion 27
 
         versionName libraryVersion
-        versionCode 60
+        versionCode 61
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 
@@ -67,7 +67,7 @@ android {
 dependencies {
     implementation "com.android.support:support-annotations:$supportLibraryVersion"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
-    implementation ("com.android.support:palette-v7:$supportLibraryVersion")
+    implementation "com.android.support:palette-v7:$supportLibraryVersion"
     implementation "com.github.bumptech.glide:glide:$glideVersion"
     kapt "com.github.bumptech.glide:compiler:$glideVersion"
     testImplementation 'junit:junit:4.12'

--- a/airbrush/src/main/java/com/subgarden/airbrush/loaders/TinyThumb.kt
+++ b/airbrush/src/main/java/com/subgarden/airbrush/loaders/TinyThumb.kt
@@ -2,11 +2,17 @@ package com.subgarden.airbrush.loaders
 
 
 /**
- * A base64 encoded jpeg. Typically very small.
+ * A base64 encoded JPEG. Typically very small.
  *
+ * @param base64 The base64 encoded JPEG
+ * @param header An optional header that can be used to reduce the size of the base64 payload
+ * @param base64DecodeFlag Optional flag to override the Base64 decode flag set by the TinyThumbDecoder.
  * @author Fredrik Larsen (fredrik@subgarden.com)
  */
-data class TinyThumb(val base64: String, val header: String = "") {
+data class TinyThumb @JvmOverloads constructor(
+        val base64: String,
+        val header: String = "",
+        val base64DecodeFlag: Int = -1) {
     init {
         require(base64.isNotEmpty()) { "Missing data. Base64 string is empty." }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,8 @@
 
 buildscript {
     ext {
-        kotlinVersion = "1.2.40" // 1.2.51 breaks renderscript compilation.
-        supportLibraryVersion = "27.1.0"
+        kotlinVersion = "1.2.61"
+        supportLibraryVersion = "27.1.1"
         glideVersion = "4.3.1"
         retrofitVersion = "2.3.0"
         okHttpVersion = "3.10.0"
@@ -13,7 +13,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath 'com.android.tools.build:gradle:3.1.4'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -12,6 +12,8 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        renderscriptTargetApi 16
+        renderscriptSupportModeEnabled true
 
     }
     buildTypes {

--- a/sample/src/main/java/com/subgarden/sample/GlideModule.kt
+++ b/sample/src/main/java/com/subgarden/sample/GlideModule.kt
@@ -2,6 +2,7 @@ package com.subgarden.sample
 
 import android.content.Context
 import android.graphics.drawable.BitmapDrawable
+import android.util.Base64
 import com.bumptech.glide.Glide
 import com.bumptech.glide.Registry
 import com.bumptech.glide.annotation.GlideModule
@@ -30,9 +31,10 @@ open class GlideModule : AppGlideModule() {
         val factory = OkHttpUrlLoader.Factory(client)
         glide.registry.replace(GlideUrl::class.java, InputStream::class.java, factory)
 
-        // This is how custom blurring can be achieved with AirBrush.
-        registry.prepend(TinyThumb::class.java, BitmapDrawable::class.java,  TinyThumbDecoder(context, glide.bitmapPool) { bitmap ->
+        // This is how AirBrush's TinyThumb can be customised. E.g. blurring and the Base64 decode flag.
+        val decoder = TinyThumbDecoder(context, glide.bitmapPool, Base64.URL_SAFE) { bitmap ->
             AirBrush.blur(context, bitmap, scale = 1f, radius = 20f)
-        })
+        }
+        registry.prepend(TinyThumb::class.java, BitmapDrawable::class.java, decoder)
     }
 }


### PR DESCRIPTION
- TinyThumbDecoder now supports a different default base64 decode flag.
- TinyThumb can now override the default base64 decode flag.
- Removed bitmapProvider from TinyThumbDecoder. A custom decoder class should be used instead.
- Added @JvmOverload to better support default arguments from Java
- Added more documentation
- Upgraded to latest kotlin and support library versions