### PR TITLE
Fix for StrictMode violation

### DIFF
--- a/airbrush/src/main/java/com/subgarden/airbrush/AirBrush.kt
+++ b/airbrush/src/main/java/com/subgarden/airbrush/AirBrush.kt
@@ -85,6 +85,7 @@ class AirBrush(private val context: Context) {
             theIntrinsic.forEach(tmpOut)
             tmpOut.copyTo(outputBitmap)
 
+            theIntrinsic.destroy()
             return outputBitmap
         }
 


### PR DESCRIPTION
StrictMode policy violation: android.os.strictmode.LeakedClosableViolation: A resource was acquired at attached stack trace but never released.
The resource is 
`val theIntrinsic = ScriptIntrinsicBlur.create(renderScript, Element.U8_4(renderScript))`